### PR TITLE
JIRA-005 include factory bot for Production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,9 +59,11 @@ gem "aws-sdk-s3", require: false
 # Use FriendlyId for slugs
 gem "friendly_id", "~> 5.1.0"
 
+# To generate factory bot models in both test and Heroku
+gem "factory_bot_rails"
+
 group :development, :test do
   gem "rspec-rails"
-  gem "factory_bot_rails"
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mswin mswin64 mingw x64_mingw ], require: "debug/prelude"
 


### PR DESCRIPTION
*  include factory bot for Production.  I don't normally do this for a real production environment, but this is a special case since it's a demonstration app